### PR TITLE
Avoid reverting in view method when no coll/debt change

### DIFF
--- a/contracts/MainController.vy
+++ b/contracts/MainController.vy
@@ -473,6 +473,9 @@ def get_pending_market_state_for_account(
     assert convert(debt, int256) + debt_change > 0, "DFM:C Negative debt"
 
     if debt == 0:
+        if coll_change == 0 and debt_change == 0:
+            return state
+
         assert coll_change > 0 and debt_change > 0, "DFM:C 0 coll or debt"
         state.hook_debt_adjustment = self._call_view_hooks(
             market,
@@ -486,7 +489,7 @@ def get_pending_market_state_for_account(
             ),
             self._positive_only_bounds(convert(debt_change, uint256))
         )
-    else:
+    elif coll_change != 0 or debt_change != 0:
         state.hook_debt_adjustment = self._call_view_hooks(
             market,
             HookId.ON_ADJUST_LOAN,


### PR DESCRIPTION
Within `get_pending_market_state_for_account`:

1. If `account` does not have an open loan, and coll/debt change are both 0, return an empty result instead of reverting.
2. If `account` has an open loan, and coll/debt change are both 0, do not apply the adjust loan hook.

This avoids reverts within the front-end when displaying the create / adjust loan modals, but before the user has given any input.  Although calls to open or adjust a loan with 0 debt and coll change would revert, the returned "pending" state with no adjustment is technically true in both cases.