### PR TITLE
Add guardian role to `DFMProtocolCore`

### DIFF
--- a/contracts/base/ProtocolCore.sol
+++ b/contracts/base/ProtocolCore.sol
@@ -67,12 +67,24 @@ contract DFMProtocolCore is IProtocolCore {
 
     /**
         @notice Address of the bridge relay
-        @dev Not set within the constructor. Bridging functionality should
-             verify that the relay is set before attempting an action. The
-             relay contract must adhere to the `IBridgeRelay` interface.
+        @dev * Not set within the constructor. Bridging functionality should
+               verify that the relay is set before attempting an action.
+             * The relay contract must adhere to the `IBridgeRelay` interface.
      */
     function bridgeRelay() external view returns (address) {
         return addressRegistry[Addresses.BRIDGE_RELAY];
+    }
+
+    /**
+        @notice Address with capability to quickly pause certain elements
+                of the protocol in the event of an exploit
+        @dev * Not set within the constructor. If using a guardian, it must be
+               set after deployment.
+             * It is critical that the guardian is not able to block an admin
+               action to change or remove the guardian.
+     */
+    function guardian() external view returns (address) {
+        return addressRegistry[Addresses.GUARDIAN];
     }
 
     function getAddress(bytes32 identifier) external view returns (address) {

--- a/contracts/base/dependencies/Addresses.sol
+++ b/contracts/base/dependencies/Addresses.sol
@@ -5,4 +5,5 @@ pragma solidity ^0.8.0;
 library Addresses {
     bytes32 internal constant BRIDGE_RELAY = bytes32("BRIDGE_RELAY");
     bytes32 internal constant FEE_RECEIVER = bytes32("FEE_RECEIVER");
+    bytes32 internal constant GUARDIAN = bytes32("GUARDIAN");
 }


### PR DESCRIPTION
Self explanatory.

Actual implementation of the guardian is out of scope for this PR, I just need this base layer merged so I can add it to several other PRs in tandem.