### PR TITLE
Enable/disable delegated ops via guardian

### DIFF
--- a/contracts/base/dependencies/CoreOwnable.sol
+++ b/contracts/base/dependencies/CoreOwnable.sol
@@ -27,6 +27,21 @@ abstract contract CoreOwnable {
         _;
     }
 
+    /**
+        @dev Access control modifier for toggle actions where the only the protocol
+             owner is allowed to enabled, but both the owner and guardian can disable.
+     */
+    modifier ownerOrGuardianToggle(bool isEnabled) {
+        if (msg.sender != owner()) {
+            if (msg.sender == guardian()) {
+                require(!isEnabled, "DFM: Guardian can only disable");
+            } else {
+                revert("DFM Not owner or guardian");
+            }
+        }
+        _;
+    }
+
     function owner() public view returns (address) {
         return address(CORE_OWNER.owner());
     }
@@ -37,5 +52,9 @@ abstract contract CoreOwnable {
 
     function feeReceiver() internal view returns (address) {
         return CORE_OWNER.feeReceiver();
+    }
+
+    function guardian() internal view returns (address) {
+        return CORE_OWNER.guardian();
     }
 }

--- a/contracts/base/dependencies/DelegatedOps.sol
+++ b/contracts/base/dependencies/DelegatedOps.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.0;
 
+import "./CoreOwnable.sol";
+
 /**
     @title Delegated Operations
     @author Prisma Finance (with edits by defidotmoney)
@@ -13,18 +15,44 @@ pragma solidity ^0.8.0;
             the call, all internal state updates should be applied for `account` and all
             value transfers should occur to or from the caller.
  */
-abstract contract DelegatedOps {
+abstract contract DelegatedOps is CoreOwnable {
     event SetDelegateApproval(address indexed caller, address indexed delegate, bool isApproved);
+    event SetDelegationEnabled(address caller, bool isEnabled);
 
     mapping(address owner => mapping(address caller => bool isApproved)) public isApprovedDelegate;
 
+    bool public isDelegationEnabled;
+
+    constructor(address _core) CoreOwnable(_core) {
+        isDelegationEnabled = true;
+    }
+
     modifier callerOrDelegated(address _account) {
-        require(msg.sender == _account || isApprovedDelegate[_account][msg.sender], "DFM: Delegate not approved");
+        if (msg.sender != _account) {
+            require(isDelegationEnabled, "DFM: Delegation disabled");
+            require(isApprovedDelegate[_account][msg.sender], "DFM: Delegate not approved");
+        }
         _;
     }
 
+    /**
+        @notice Enable or disable a delegate to perform actions on behalf of the caller
+        @param _delegate Address of the delegate to set approval for
+        @param _isApproved Is delegate approved?
+     */
     function setDelegateApproval(address _delegate, bool _isApproved) external {
         isApprovedDelegate[msg.sender][_delegate] = _isApproved;
         emit SetDelegateApproval(msg.sender, _delegate, _isApproved);
+    }
+
+    /**
+        @notice Enable or disable all delegated operations within this contract
+        @dev Delegated operations are enabled by default upon deployment.
+             Only the owner can enable. The owner or the guardian can disable.
+        @param _isEnabled Are delegated operations approved?
+     */
+    function setDelegationEnabled(bool _isEnabled) external ownerOrGuardianToggle(_isEnabled) {
+        isDelegationEnabled = _isEnabled;
+        emit SetDelegationEnabled(msg.sender, _isEnabled);
     }
 }

--- a/contracts/interfaces/IProtocolCore.sol
+++ b/contracts/interfaces/IProtocolCore.sol
@@ -12,4 +12,6 @@ interface IProtocolCore {
     function bridgeRelay() external view returns (address);
 
     function feeReceiver() external view returns (address);
+
+    function guardian() external view returns (address);
 }


### PR DESCRIPTION
Apply the guardian within `DelegatedOps`:

* the owner or guardian can both disable all delegated operations within a contract
* only the owner may re-enable

As a side effect, `DelegatedOps` now inherits `CoreOwnable`.