### PR TITLE
Do not revert in hook view methods

### DIFF
--- a/contracts/periphery/hooks/L2SequencerUptimeHook.sol
+++ b/contracts/periphery/hooks/L2SequencerUptimeHook.sol
@@ -28,7 +28,7 @@ contract L2SequencerUptimeHook {
         uint256 collAmount,
         uint256 debtAmount
     ) external returns (int256 debtAdjustment) {
-        _onCreate();
+        require(uptimeOracle.getUptimeStatus(), "DFM: Sequencer down, no new loan");
         return 0;
     }
 
@@ -38,7 +38,6 @@ contract L2SequencerUptimeHook {
         uint256 collAmount,
         uint256 debtAmount
     ) external view returns (int256 debtAdjustment) {
-        _onCreate();
         return 0;
     }
 
@@ -48,7 +47,12 @@ contract L2SequencerUptimeHook {
         int256 collChange,
         int256 debtChange
     ) external returns (int256 debtAdjustment) {
-        _onAdjust(collChange, debtChange);
+        if (debtChange > 0 || collChange < 0) {
+            if (!uptimeOracle.getUptimeStatus()) {
+                if (debtChange > 0) revert("DFM: Sequencer down, no debt++");
+                else revert("DFM: Sequencer down, no coll--");
+            }
+        }
         return 0;
     }
 
@@ -58,20 +62,6 @@ contract L2SequencerUptimeHook {
         int256 collChange,
         int256 debtChange
     ) external returns (int256 debtAdjustment) {
-        _onAdjust(collChange, debtChange);
         return 0;
-    }
-
-    function _onCreate() internal view {
-        require(uptimeOracle.getUptimeStatus(), "DFM: Sequencer down, no new loan");
-    }
-
-    function _onAdjust(int256 collChange, int256 debtChange) internal view {
-        if (debtChange > 0 || collChange < 0) {
-            if (!uptimeOracle.getUptimeStatus()) {
-                if (debtChange > 0) revert("DFM: Sequencer down, no debt++");
-                else revert("DFM: Sequencer down, no coll--");
-            }
-        }
     }
 }

--- a/contracts/periphery/hooks/WhitelistHook.vy
+++ b/contracts/periphery/hooks/WhitelistHook.vy
@@ -30,13 +30,13 @@ def get_configuration() -> (uint256, bool[4]):
 @view
 @external
 def on_create_loan_view(account: address, market: address, coll_amount: uint256, debt_amount: uint256) -> int256:
-    return self._assert_is_whitelisted(account)
+    return 0
 
 
 @external
 def on_create_loan(account: address, market: address, coll_amount: uint256, debt_amount: uint256) -> int256:
-    return self._assert_is_whitelisted(account)
-
+    assert self.is_whitelisted[account], "DFM: not whitelisted"
+    return 0
 
 @external
 def set_owner(owner: address):
@@ -50,10 +50,3 @@ def set_whitelisted(accounts: DynArray[address, max_value(uint16)], is_whitelist
     for account in accounts:
         self.is_whitelisted[account] = is_whitelisted
         log WhitelistSet(account, is_whitelisted)
-
-
-@view
-@internal
-def _assert_is_whitelisted(account: address) -> int256:
-    assert self.is_whitelisted[account], "DFM: not whitelisted"
-    return 0

--- a/interfaces/IControllerHooks.sol
+++ b/interfaces/IControllerHooks.sol
@@ -48,6 +48,10 @@ interface IControllerHooks {
         uint256 debtAmount
     ) external returns (int256 debtAdjustment);
 
+    /**
+        @dev Read-only implementation of `on_create_loan` used for pending state calculations.
+             If the nonpayable version would revert, this function should instead return 0.
+     */
     function on_create_loan_view(
         address account,
         address market,
@@ -72,6 +76,10 @@ interface IControllerHooks {
         int256 debtChange
     ) external returns (int256 debtAdjustment);
 
+    /**
+        @dev Read-only implementation of `on_adjust_loan` used for pending state calculations.
+             If the nonpayable version would revert, this function should instead return 0.
+     */
     function on_adjust_loan_view(
         address account,
         address market,
@@ -93,6 +101,10 @@ interface IControllerHooks {
         uint256 accountDebt
     ) external returns (int256 debtAdjustment);
 
+    /**
+        @dev Read-only implementation of `on_close_loan` used for pending state calculations.
+             If the nonpayable version would revert, this function should instead return 0.
+     */
     function on_close_loan_view(
         address account,
         address market,
@@ -114,6 +126,10 @@ interface IControllerHooks {
         uint256 debtLiquidated
     ) external returns (int256 debtAdjustment);
 
+    /**
+        @dev Read-only implementation of `on_liquidation` used for pending state calculations.
+             If the nonpayable version would revert, this function should instead return 0.
+     */
     function on_liquidation_view(
         address caller,
         address market,


### PR DESCRIPTION
* Adjust hook contracts to return 0 rather than revert in the view methods.
* Reverting in the views is causing the FE to break unexpectedly in very many places.
* It's cleaner if the action fails when attempting the transaction rather than breaking the site.