### PR TITLE
Add `addCollateral` to leverage zap

### DIFF
--- a/contracts/interfaces/IMarketOperator.sol
+++ b/contracts/interfaces/IMarketOperator.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IMarketOperator {
+    function debt(address account) external view returns (uint256);
+}

--- a/contracts/periphery/zaps/LeverageZap.sol
+++ b/contracts/periphery/zaps/LeverageZap.sol
@@ -167,15 +167,15 @@ contract LeverageZapOdosV2 is ReentrancyGuard, IERC3156FlashBorrower {
         IERC20 collateral = _getCollateralOrRevert(market);
         if (collAmount > 0) collateral.safeTransferFrom(msg.sender, address(this), collAmount);
 
-        uint256 debt = IMarketOperator(market).debt(msg.sender);
-        require(debt > debtAmount);
+        uint256 debtOwed = IMarketOperator(market).debt(msg.sender);
+        require(debtOwed > debtAmount, "DFM: debtAmount >= debtOwed");
         if (debtAmount > 0) {
             stableCoin.transferFrom(msg.sender, address(this), debtAmount);
-            debt -= debtAmount;
+            debtOwed -= debtAmount;
         }
 
         bytes memory data = abi.encode(Action.AddColl, msg.sender, market, collateral, numBands, routingData);
-        stableCoin.flashLoan(this, address(stableCoin), debt, data);
+        stableCoin.flashLoan(this, address(stableCoin), debtOwed, data);
     }
 
     /**

--- a/scripts/periphery/leverage_zap.py
+++ b/scripts/periphery/leverage_zap.py
@@ -53,7 +53,7 @@ def get_close_loan_routing_data(zap, account, market, use_account_balance=True, 
         int: Expected amount of MONEY received in the swap, as an integer with 1e18 precision
     """
     controller = Contract(CONTROLLER)
-    token = controller.get_collateral(market)
+    token = Contract(controller.get_collateral(market))
 
     amount = Contract(MONEY).balanceOf(account) if use_account_balance else 0
     (debt, coll) = controller.get_close_loan_amounts(account, market)
@@ -65,11 +65,12 @@ def get_close_loan_routing_data(zap, account, market, use_account_balance=True, 
     assert shortfall > 0
 
     amount_out = shortfall / controller.get_oracle_price(token) * (1 + max_slippage)
+    amount_out = to_int(amount, token.decimals())
 
     amount_in, path_id = get_quote(chain.id, zap, token, MONEY, amount_out, max_slippage)
 
     while amount_in < shortfall:
-        amount_out *= shortfall / amount_in
+        amount_out = int(amount_out * shortfall / amount_in)
         amount_in, path_id = get_quote(chain.id, zap, token, MONEY, amount_out, max_slippage)
 
     return get_route_calldata(zap, path_id), amount_out, amount_in
@@ -93,7 +94,8 @@ def get_add_coll_routing_data(zap, account, market, coll_amount, max_slippage=0.
 
     Returns:
         string: `routingData` for use in `LeverageZap.closeLoan`
-        int: New collateral balance that will be backing the loan
+        int: New collateral balance that will be backing the loan, as an integer with
+             the same precision used in the token smart contract
     """
     controller = Contract(CONTROLLER)
     token, amm = controller.market_contracts(market)[:-1]
@@ -106,15 +108,16 @@ def get_add_coll_routing_data(zap, account, market, coll_amount, max_slippage=0.
     return get_route_calldata(zap, path_id), coll_amount + coll_amm + received
 
 
-def get_quote(chain_id, caller, input_token, output_token, amount, max_slippage=0.003):
-    if not isinstance(input_token, Contract):
-        input_token = Contract(input_token)
-    amount = to_int(amount, input_token.decimals())
-
+def get_quote(chain_id, caller, input_token, output_token, amount_in, max_slippage=0.003):
+    """
+    Args:
+        amount_in: Amount of input_token being swapped, as an integer with the same precision
+            used in the token smart contract
+    """
     quote_request_body = {
         "chainId": chain_id,
         "inputTokens": [
-            {"tokenAddress": to_checksum_address(str(input_token)), "amount": str(amount)}
+            {"tokenAddress": to_checksum_address(str(input_token)), "amount": str(amount_in)}
         ],
         "outputTokens": [{"tokenAddress": to_checksum_address(str(output_token)), "proportion": 1}],
         "slippageLimitPercent": max_slippage * 100,

--- a/tests/brownie/periphery/leverage_odos/test_add_coll.py
+++ b/tests/brownie/periphery/leverage_odos/test_add_coll.py
@@ -1,0 +1,82 @@
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(controller, market, stable, collateral, amm, dummy_oracle, zap, alice, bob, deployer):
+    stable.approve(zap, 2**256 - 1, {"from": alice})
+    collateral.approve(controller, 2**256 - 1, {"from": alice})
+    collateral.approve(zap, 2**256 - 1, {"from": alice})
+
+    stable.mint(bob, 100_000 * 10**18, {"from": controller})
+    stable.approve(amm, 2**256 - 1, {"from": bob})
+
+    collateral._mint_for_testing(alice, 10 * 10**18, {"from": alice})
+    controller.setDelegateApproval(zap, True, {"from": alice})
+
+    controller.create_loan(alice, market, 5 * 10**18, 10_000 * 10**18, 10, {"from": alice})
+    band = amm.read_user_tick_numbers(alice)[0] + 5
+    price = amm.p_oracle_up(band)
+    dummy_oracle.set_price(price, {"from": deployer})
+    amm.exchange(0, 1, 6000 * 10**18, 0, {"from": bob})
+
+
+def test_initial_setup(controller, market, amm, alice):
+    assert min(amm.get_sum_xy(alice)) > 0
+
+
+def test_add_coll(market, amm, collateral, stable, router, zap, alice):
+    stable_amount, coll_amount = amm.get_sum_xy(alice)
+    data = router.mockSwap.encode_input(stable, collateral, stable_amount, 2 * 10**18)
+    zap.addCollateral(market, 10**18, 0, 10, data, {"from": alice})
+
+    assert amm.get_sum_xy(alice) == (0, coll_amount + 3 * 10**18)
+    assert market.debt(alice) == 10_000 * 10**18
+
+    assert stable.balanceOf(alice) == 10_000 * 10**18
+    assert stable.balanceOf(zap) == 0
+
+    assert collateral.balanceOf(alice) == 4 * 10**18
+    assert collateral.balanceOf(zap) == 0
+
+
+@pytest.mark.parametrize("num_bands", [4, 10, 20])
+def test_add_coll_modify_num_bands(market, amm, collateral, stable, router, zap, alice, num_bands):
+    stable_amount = amm.get_sum_xy(alice)[0]
+    data = router.mockSwap.encode_input(stable, collateral, stable_amount, 2 * 10**18)
+    zap.addCollateral(market, 10**18, 0, num_bands, data, {"from": alice})
+
+    bands = amm.read_user_tick_numbers(alice)
+    assert bands[1] + 1 - bands[0] == num_bands
+
+
+def test_add_coll_with_debt_amount(market, amm, collateral, stable, router, zap, alice):
+    stable_amount, coll_amount = amm.get_sum_xy(alice)
+    data = router.mockSwap.encode_input(stable, collateral, stable_amount, 2 * 10**18)
+    zap.addCollateral(market, 10**18, 2_000 * 10**18, 10, data, {"from": alice})
+
+    assert amm.get_sum_xy(alice) == (0, coll_amount + 3 * 10**18)
+    assert market.debt(alice) == 8_000 * 10**18
+
+    assert stable.balanceOf(alice) == 8_000 * 10**18
+    assert stable.balanceOf(zap) == 0
+
+    assert collateral.balanceOf(alice) == 4 * 10**18
+    assert collateral.balanceOf(zap) == 0
+
+
+def test_add_coll_partial_swap(market, amm, collateral, stable, router, zap, alice):
+    stable_amount, coll_amount = amm.get_sum_xy(alice)
+    data = router.mockSwap.encode_input(
+        stable, collateral, stable_amount - 1_500 * 10**18, 2 * 10**18
+    )
+    zap.addCollateral(market, 10**18, 0, 10, data, {"from": alice})
+
+    assert amm.get_sum_xy(alice) == (0, coll_amount + 3 * 10**18)
+    assert market.debt(alice) == 8_500 * 10**18
+
+    assert stable.balanceOf(alice) == 10_000 * 10**18
+    assert stable.balanceOf(zap) == 0
+
+    assert collateral.balanceOf(alice) == 4 * 10**18
+    assert collateral.balanceOf(zap) == 0


### PR DESCRIPTION
Adds a new function to the leverage zap `addCollateral`, which:

1. Opens a flashloan and uses it to close the caller's loan
2. Swaps stablecoins received from closing the loan for more collateral
3. Opens a new loan with the original collateral, swapped collateral, and any collateral received from the user
4. Repays the flashloan with the stablecoins received from opening the new loan

This effectively allows users to deposit additional collateral to a loan that's currently under collateral conversion, moving the loan out of the converted state.